### PR TITLE
Webhooks docs initial

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -1,0 +1,54 @@
+# Webhooks
+
+Webhooks allow you to be notified of events that happen on your Affinity instance. For example, your app can be notified when a list is created, a field value is updated, a person is deleted, and more.
+
+## Create a Webhook Subscription
+
+
+
+## Supported Webhook Events
+
+List Events
+'list.created'
+'list.updated'
+'list.deleted'
+'list_entry.created'
+'list_entry.deleted'
+
+Note Events
+'note.created'
+'note.updated'
+'note.deleted'
+
+Field Events
+'field.created'
+'field.updated'
+'field.deleted'
+'field_value.created'
+'field_value.updated'
+'field_value.deleted'
+
+Person Events
+'person.created'
+'person.updated'
+'person.deleted'
+
+Organization Events
+'organization.created'
+'organization.updated'
+'organization.deleted'
+
+Opportunity Events
+'opportunity.created'
+'opportunity.updated'
+'opportunity.deleted'
+
+File Events
+'file.created'
+'file.deleted'
+
+## Limitations
+
+We don't yet have a way for you to only subscribe to certain events - it's all or nothing.
+There is no UI to entire the URL that we'll POST to. You'll just have to give them to me via email.
+There are some conditions that won't trigger webhooks just yet: Data/Note Imports, EmailBot related events, Automated organization creation and Automated global organization field updates (crunchbase fields like last round raised, location, etc.).

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -1,6 +1,6 @@
 # Webhooks
 
-Webhooks allow you to be notified of events that happen on your Affinity instance. For example, your app can be notified when a list is created, a field value is updated, a person is deleted, and more.
+Webhooks allow you to be notified of events that happen on your Affinity instance. For example, your app can be notified when a list is created, a field value is updated, a person is deleted, and more. These events will fire immediately after the corresponding action takes place.
 
 ## Create a Webhook Subscription
 
@@ -53,6 +53,6 @@ We don't currently support this via the API. Please reach out to support@affinit
 no way to only subscribe to certain events.
 - The following triggers will not create webhook events:
 	- resources created/updated/deleted via our importer tool
-	- resources created/updated/delete via Email Bot.
+	- resources created/updated/deleted via Email Bot.
 	- organizations created automatically based on email/event interactions.
-	- automated global organization fields (i.e. location, last round raised, etc.)
+	- field values created/updated/deleted in automated global organization fields (i.e. location, last round raised, etc.)

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -4,51 +4,55 @@ Webhooks allow you to be notified of events that happen on your Affinity instanc
 
 ## Create a Webhook Subscription
 
-
+We don't currently support this via the API. Please reach out to support@affinity.co with the URL you would like us to POST webhooks to.
 
 ## Supported Webhook Events
 
-List Events
-'list.created'
-'list.updated'
-'list.deleted'
-'list_entry.created'
-'list_entry.deleted'
+### List Events
+- 'list.created'
+- 'list.updated'
+- 'list.deleted'
+- 'list_entry.created'
+- 'list_entry.deleted'
 
-Note Events
-'note.created'
-'note.updated'
-'note.deleted'
+### Note Events
+- 'note.created'
+- 'note.updated'
+- 'note.deleted'
 
-Field Events
-'field.created'
-'field.updated'
-'field.deleted'
-'field_value.created'
-'field_value.updated'
-'field_value.deleted'
+### Field Events
+- 'field.created'
+- 'field.updated'
+- 'field.deleted'
+- 'field_value.created'
+- 'field_value.updated'
+- 'field_value.deleted'
 
-Person Events
-'person.created'
-'person.updated'
-'person.deleted'
+### Person Events
+- 'person.created'
+- 'person.updated'
+- 'person.deleted'
 
-Organization Events
-'organization.created'
-'organization.updated'
-'organization.deleted'
+### Organization Events
+- 'organization.created'
+- 'organization.updated'
+- 'organization.deleted'
 
-Opportunity Events
-'opportunity.created'
-'opportunity.updated'
-'opportunity.deleted'
+### Opportunity Events
+- 'opportunity.created'
+- 'opportunity.updated'
+- 'opportunity.deleted'
 
-File Events
-'file.created'
-'file.deleted'
+### Entity File Events
+- 'file.created'
+- 'file.deleted'
 
 ## Limitations
 
-We don't yet have a way for you to only subscribe to certain events - it's all or nothing.
-There is no UI to entire the URL that we'll POST to. You'll just have to give them to me via email.
-There are some conditions that won't trigger webhooks just yet: Data/Note Imports, EmailBot related events, Automated organization creation and Automated global organization field updates (crunchbase fields like last round raised, location, etc.).
+- A webhook subscription automatically subscribes to all events, there is currently
+no way to only subscribe to certain events.
+- The following triggers will not create webhook events:
+	- resources created/updated/deleted via our importer tool
+	- resources created/updated/delete via Email Bot.
+	- organizations created automatically based on email/event interactions.
+	- automated global organization fields (i.e. location, last round raised, etc.)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,6 +18,7 @@ includes:
   - entity-values
   - notes
   - entity-files
+  - webhooks
   - additional-materials
 
 ---


### PR DESCRIPTION
Some very sparse documentation on webhooks so customers at least know they can reach out to support if they'd like to subscribe. Once we build this feature out a little more I imagine these docs will be a lot more verbose and cover a lot more edge cases. We'll also allow people to create subscriptions via API.