### PR TITLE
Put CNAME in source

### DIFF
--- a/source/CNAME
+++ b/source/CNAME
@@ -1,0 +1,1 @@
+api-docs.affinity.co


### PR DESCRIPTION
This way the deploy script will copy CNAME to the root directory of gh-pages