### PR TITLE
Remove limitations on dataset webhooks.

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -183,4 +183,4 @@ Deletes a webhook subscription with a specified `webhook_subscription_id`.
 
 ## Limitations
 
-There is a limit of three webhook subscriptions. If you have any questions at all regarding webhooks, please reach out to <support@affinity.co>.
+There is a limit of three webhook subscriptions per Affinity instance. If you have any questions at all regarding webhooks, please reach out to <support@affinity.co>.

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -183,11 +183,4 @@ Deletes a webhook subscription with a specified `webhook_subscription_id`.
 
 ## Limitations
 
-- The following triggers will not create webhook events:
-
-  - Resources created/updated/deleted via our importer tool
-  - Resources created/updated/deleted via Email Bot.
-  - Organizations created automatically based on email/event interactions.
-  - Field values created/updated/deleted in automated global organization fields (i.e. location, last round raised, etc.)
-
-- There is a limit of three webhook subscriptions. If you have any questions at all regarding webhooks, please reach out to support@affinity.co.
+There is a limit of three webhook subscriptions. If you have any questions at all regarding webhooks, please reach out to <support@affinity.co>.


### PR DESCRIPTION
Remove limitations on dataset hooks in the webhooks section, now that we're migrating to use the legacy webhooks feature gating.

Also fixed support email link.

![Screen Shot 2020-05-07 at 4 06 51 PM](https://user-images.githubusercontent.com/16326980/81353100-0eb0c900-907d-11ea-83bf-e855180fc3fd.png)

