### PR TITLE
Fix example get request for entity attributes.

### DIFF
--- a/source/includes/_entity-attributes.md
+++ b/source/includes/_entity-attributes.md
@@ -74,7 +74,7 @@ For accessing list specific fields on a list, see the [Specific List](#get-a-spe
 ```shell
 curl "https://api.affinity.co/fields" \
   -u :<API-KEY> \
-  -d with_modified_names=true \
+  -d with_modified_names=true
 ```
 
 > Example Response


### PR DESCRIPTION
Remove trailing `\` from the GET request.

https://app.asana.com/0/1176772761628309/1179558423045913