### PR TITLE
[Bug Fix] Updated contents related to API:

### DIFF
--- a/source/includes/_list-entries.md
+++ b/source/includes/_list-entries.md
@@ -258,7 +258,6 @@ The list entry resource that was just created through this request.
 ```shell
 curl "https://api.affinity.co/lists/450/list-entries/56517" \
    -u :<API-KEY> \
-   -d entity_id=38706 \
    -X "DELETE"
 ```
 

--- a/source/includes/_opps.md
+++ b/source/includes/_opps.md
@@ -52,12 +52,10 @@ Of course, all fields can be modified and the opportunity can be deleted.
 | Attribute        | Type        | Description                                                                                     |
 | ---------------- | ----------- | ----------------------------------------------------------------------------------------------- |
 | id               | integer     | The unique identifier of the opportunity object.                                                |
-| name             | integer     | The name of the opportunity (see below).                                                        |
+| name             | string      | The name of the opportunity (see below).                                                        |
 | person_ids       | number[]    | An array of unique identifiers for persons that are associated with the opportunity             |
 | organization_ids | number[]    | An array of unique identifiers for organizations that are associated with the opportunity       |
-| list_entries     | ListEntry[] | An array of list entry resources associated with the opportunity (at most 1 list entry). If the |
-
-user corresponding to the API key does not have access to the list, this will be empty.
+| list_entries     | ListEntry[] | An array of list entry resources associated with the opportunity (at most 1 list entry). If the user corresponding to the API key does not have access to the list, this will be empty. |
 
 ## Search for opportunities
 

--- a/source/includes/_organizations.md
+++ b/source/includes/_organizations.md
@@ -153,7 +153,10 @@ interaction.
 
 You can filter by interaction dates by providing additional query parameters like
 `min_last_email_date` or `max_next_event_date`. The value of these query parameters should
-be ISO 8601 formatted date strings.
+be ISO 8601 formatted date strings. The interaction dates are stored with timestamps,
+so the `{min,max}_<interaction>_date` parameter can include or exclude timestamps to explicitly
+filter the dataset. If a timestamp is not provided, the system will use the default value of 
+`00:00:00`.
 
 > Example Request
 
@@ -192,7 +195,20 @@ curl "https://api.affinity.co/organizations?term=affinity" -u :<API-KEY>
 
 ```shell
 # To get the second page of results, issue the following query:
-curl "https://api.affinity.co/organizations?term=affinity&page_token=eyJwYXJhbXMiOnsidGVybSI6IiJ9LCJwYWdlX3NpemUiOjUsIm9mZnNldCI6MTB9" -u :<API-KEY>
+curl --request GET  "https://api.affinity.co/organizations" \
+  -u :<API-KEY> \
+  -d page_token=eyJwYXJhbXMiOnsidGVybSI6IiJ9LCJwYWdlX3NpemUiOjUsIm9mZnNldCI6MTB9
+```
+
+> Example with interaction date
+
+```shell
+# To get the results between min_last_email_interaction_date and max_last_email_interaction_date, issue the following query:
+curl --request GET "https://api.affinity.co/organizations" \
+  -u :<API-KEY> \
+  -d min_last_email_date=2021-01-01T00:00:00 \
+  -d with_interaction_dates=true \
+  -d max_last_email_date=2021-01-12T23:59:59
 ```
 
 ### Query Parameters


### PR DESCRIPTION
## Description

This change is addressing 3 API documentation bugs

### 1. Search Organizations  API

**Asana Task**: `https://app.asana.com/0/572858660383888/1199669815635181/f`

The fix is to let the user know that `{min,max}_<interaction>_date`(Query param) can accept timestamps in the input. The content is updated as per the text decided in the Asana task.

![Screen Shot 2021-02-25 at 2 42 18 PM](https://user-images.githubusercontent.com/79168430/109208213-0b0b4180-7778-11eb-86b1-7cf6d3d6863b.png)


### 2. Delete specific list entry API

**Asana Task**: `https://app.asana.com/0/572858660383888/1199927729942320/f`

The fix is to update the example of the Delete Specific List Entry API. Example include the option to provide `entity_id ` in the request which is not required.

![Screen Shot 2021-02-25 at 10 53 25 AM](https://user-images.githubusercontent.com/79168430/109179378-d2f40680-7757-11eb-8fcf-1f3a96225fa2.png)



### 3. Opportunity API

**Asana Task**: `https://app.asana.com/0/572858660383888/1199897894649671/f`

The fix is to update the opportunity resource description. Changes are:
- Updated `name ` attribute of type `String`
- Fix the indentation of `description` section for `list_entries ` attribute

![Screen Shot 2021-02-24 at 12 25 00 PM](https://user-images.githubusercontent.com/79168430/109044021-e80d5e80-769f-11eb-9889-2a7b2963c983.png)


Will Cherry-pick the commit from `master` to `gh-pages` branch once the PR is merged.