### PR TITLE
Fix typo in the notes api docs

### DIFF
--- a/source/includes/_notes.md
+++ b/source/includes/_notes.md
@@ -74,7 +74,7 @@ curl "https://api.affinity.co/notes" -u :<API-KEY>
 
 `GET /notes`
 
-Returns all field values attached to a `person`, `organization`, `opportunity`.
+Returns all notes attached to a `person`, `organization`, `opportunity`.
 
 ### Query Parameters
 


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1199933461955492/1200096855827724/f

## Description
Fix the typo in the Notes API documentations
