### PR TITLE
Add new API for updating Webhook subscriptions

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -15,7 +15,8 @@ Webhooks allow you to be notified of events that happen on your Affinity instanc
     "person.created",
     "organization.created",
     "opportunity.created"
-  ]
+  ],
+  "disabled": false
 }
 ```
 
@@ -26,6 +27,7 @@ Each webhook subscription object has a unique `id`. It also has a `webhook_url` 
 | id            | integer  | The unique identifier of the webhook subscription object.                                                                                                                                                             |
 | webhook_url   | string   | The URL to which the webhooks are sent to.                                                                                                                                                                            |
 | subscriptions | string[] | An array of webhook events that are enabled for that endpoint. An empty array indicates subscription to all webhook events. See [below](#supported-webhook-events) for the complete list of supported webhook events. |
+| disabled      | boolean  | If the subscription is disabled, this is true. Otherwise, this is false. |
 
 ## Supported Webhook Events
 
@@ -63,12 +65,14 @@ curl "https://api.affinity.co/webhook" -u :<API-KEY>
       "person.created",
       "organization.created",
       "opportunity.created"
-    ]
+    ],
+    "disabled": false
   },
   {
     "id": 2345,
     "webhook_url": "https://hooks.example.com/webhook-all",
-    "subscriptions": []
+    "subscriptions": [],
+    "disabled": true
   }
 ]
 ```
@@ -96,7 +100,8 @@ curl "https://api.affinity.co/webhook/1234" -u :<API-KEY>
     "person.created",
     "organization.created",
     "opportunity.created"
-  ]
+  ],
+  "disabled": false
 }
 ```
 
@@ -130,7 +135,8 @@ curl "https://api.affinity.co/webhook/subscribe" \
 {
   "id": 1234,
   "webhook_url": "https://hooks.example.com/webhook",
-  "subscriptions": []
+  "subscriptions": [],
+  "disabled": false
 }
 ```
 
@@ -152,6 +158,45 @@ There is currently a limit of 3 webhook subscriptions.
 ### Returns
 
 The webhook subscription object that was just created from this successful request.
+
+## Update a webhook subscription
+
+> Example Request
+
+```shell
+curl "https://api.affinity.co/webhook/1234" \
+  -u :<API-KEY> \
+  -d webhook_url="https://hooks.example.com/webhook" \
+  -d disabled=true \
+  -X "PUT"
+```
+
+> Example Response
+
+```json
+{
+  "id": 1234,
+  "webhook_url": "https://hooks.example.com/webhook",
+  "subscriptions": [],
+  "disabled": true
+}
+```
+
+`PUT /webhook/{webhook_subscription_id}`
+
+Update webhook subscription with the supplied parameters. If the endpoint returns an invalid response, the webhook update will fail.
+
+### Payload Parameters
+
+| Parameter     | Type     | Required | Description                                                                                                                                                                                                                                          |
+| ------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| webhook_url   | string   | false     | The URL to which the webhooks will be sent to.                                                                                                                                                                                                       |
+| subscriptions | string[] | false    | An array of webhook events that will be enabled for that endpoint. Leave out this parameter or pass an empty array to subscribe to all webhook events. You can find the complete list of supported webhook events [here](#supported-webhook-events). |
+| disabled      | boolean  | false    | Change the status of a subscription. To enable a subscription, provide the value as `true`. Otherwise, provide the value as `false.` |
+
+### Returns
+
+The webhook subscription object that was just updated from this successful request.
 
 ## Delete a specific webhook subscription
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -27,7 +27,7 @@ Each webhook subscription object has a unique `id`. It also has a `webhook_url` 
 | id            | integer  | The unique identifier of the webhook subscription object.                                                                                                                                                             |
 | webhook_url   | string   | The URL to which the webhooks are sent to.                                                                                                                                                                            |
 | subscriptions | string[] | An array of webhook events that are enabled for that endpoint. An empty array indicates subscription to all webhook events. See [below](#supported-webhook-events) for the complete list of supported webhook events. |
-| disabled      | boolean  | If the subscription is disabled, this is true. Otherwise, this is false. |
+| disabled      | boolean  | If the subscription is disabled, this is true. Otherwise, this is false by default. A subscription may be disabled manually via API or automatically if we are not able to process it.|
 
 ## Supported Webhook Events
 
@@ -192,7 +192,7 @@ Update webhook subscription with the supplied parameters. If the endpoint return
 | ------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | webhook_url   | string   | false     | The URL to which the webhooks will be sent to.                                                                                                                                                                                                       |
 | subscriptions | string[] | false    | An array of webhook events that will be enabled for that endpoint. Leave out this parameter or pass an empty array to subscribe to all webhook events. You can find the complete list of supported webhook events [here](#supported-webhook-events). |
-| disabled      | boolean  | false    | Change the status of a subscription. To enable a subscription, provide the value as `true`. Otherwise, provide the value as `false.` |
+| disabled      | boolean  | false    | Change the status of a subscription. To enable a subscription, provide the value as `false`. Otherwise, provide the value as `true.` |
 
 ### Returns
 


### PR DESCRIPTION
**Asana Task**: https://app.asana.com/0/1199933461955492/1200272129615846/f

## Description
The PR includes the following changes to our API Docs
- Return subscription status as a response of `GET` and `POST` call
- New API `PUT` to update the existing subscription


![Screen Shot 2021-05-04 at 3 32 44 PM](https://user-images.githubusercontent.com/79168430/117059601-face9000-aced-11eb-8bbf-184cb8c81a24.png)
