### PR TITLE
Fix file upload docs

### DIFF
--- a/source/includes/_entity-files.md
+++ b/source/includes/_entity-files.md
@@ -19,16 +19,16 @@ Entity files are files uploaded to a relevant entity. Possible files, for exampl
 }
 ```
 
-| Attribute      | Type     | Description                                                                 |
-| -------------- | -------- | --------------------------------------------------------------------------- |
-| id             | integer  | The unique identifier of the entity file object.                            |
-| name           | string   | The name of the file.                                                       |
-| size           | string   | The size of the file in bytes.                                              |
+| Attribute       | Type     | Description                                                                 |
+| --------------- | -------- | --------------------------------------------------------------------------- |
+| id              | integer  | The unique identifier of the entity file object.                            |
+| name            | string   | The name of the file.                                                       |
+| size            | string   | The size of the file in bytes.                                              |
 | person_id       | integer  | The unique identifier of the person corresponding to the entity file.       |
 | organization_id | integer  | The unique identifier of the organization corresponding to the entity file. |
 | opportunity_id  | integer  | The unique identifier of the opportunity corresponding to the entity file.  |
 | uploader_id     | integer  | The unique identifier of the user who created the entity file.              |
-| created_at     | datetime | The time when the entity file was created.                                  |
+| created_at      | datetime | The time when the entity file was created.                                  |
 
 ## Get All Files
 

--- a/source/includes/_entity-files.md
+++ b/source/includes/_entity-files.md
@@ -175,16 +175,27 @@ The actual entity file corresponding to the `entity_file_id`.
   <p>The download location of entity files is provided via a redirect from our endpoint and requires the <code>-L</code> flag.</p>
 </aside>
 
-
 ## Upload Files
 
 > Example Request
 
 ```shell
+# Single file upload
 curl -X POST "https://api.affinity.co/entity-files" \
   -u :$APIKEY \
-  -H "Content-Type: application/json" \
-  -F '{"files": ["@Pitch.pdf", "@10_01_18_meeting.txt", "person_id": 4113456]}'
+  -H 'Content-Type: multipart/form-data' \
+  -F file=@file.txt \
+  -F person_id=1
+```
+
+```shell
+# Multi file upload
+curl -X POST "https://api.affinity.co/entity-files" \
+  -u :$APIKEY \
+  -H 'Content-Type: multipart/form-data' \
+  -F 'files[]=@file1.txt' \
+  -F 'files[]=@file2.txt' \
+  -F person_id=1
 ```
 
 > Example Response


### PR DESCRIPTION
Fixes the file upload examples. Specifically, the following two pieces were incorrect:
- The `Content-Type` header was incorrectly specified as `application/json`. This has been corrected to `multipart/form-data`.
- The `files` parameter was incorrectly provided as a json string of `-F '{"files": ["@Pitch.pdf", "@10_01_18_meeting.txt", "person_id": 4113456]}'`. Interestingly, this part example was using the form option `-F`, but with a json value that would normally be provided via an `application/json` payload.

I've also included two different examples - one for single file upload, and one for multi file upload. Additionally, the example includes a `person_id` parameter, because at least one of `person_Id`, `organization_id`, or `opportunity_id` are required. 

All told, both examples actually run successfully. 

![image](https://user-images.githubusercontent.com/6620895/218553829-bee54e7c-a384-4457-94a5-5951c3748a2a.png)
